### PR TITLE
add default timeout support, update constants

### DIFF
--- a/packages/core/src/server/constants/index.js
+++ b/packages/core/src/server/constants/index.js
@@ -1,0 +1,2 @@
+export const DEFAULT_TIMEOUT = 15000; // 15s
+export const DEFAULT_DELAY = 5000; // 5s

--- a/packages/core/src/server/fetch.js
+++ b/packages/core/src/server/fetch.js
@@ -1,16 +1,17 @@
 import fetch from 'cross-fetch';
 import fetchFile from './fetch-file';
+import { DEFAULT_DELAY, DEFAULT_TIMEOUT } from './constants';
 
 const sleep = ms => new Promise(resolve => ms > 0 ? setTimeout(resolve, ms) : resolve());
 
-const smartFetch = (url, { delay = 5000, retries = 0, ...options } = {}) => {
+const smartFetch = (url, { delay = DEFAULT_DELAY, timeout = DEFAULT_TIMEOUT, retries = 0, ...options } = {}) => {
   if (url.startsWith('file:')) {
     return fetchFile(url);
   }
   const retry = retries-- > 0
     ? () => sleep(delay).then(() => smartFetch(url, { ...options, delay, retries }))
     : false;
-  return fetch(url, options).then(res => !res.ok && res.status !== 304 && retry ? retry() : res, err => {
+  return fetch(url, { ...options, timeout }).then(res => !res.ok && res.status !== 304 && retry ? retry() : res, err => {
     if (retry) {
       return retry();
     }

--- a/packages/core/src/server/index.js
+++ b/packages/core/src/server/index.js
@@ -1,3 +1,4 @@
+export * as constants from './constants';
 export { default as fetch } from './fetch';
 export { default as fetchFile } from './fetch-file';
 export { default as fetchJson } from './fetch-json';

--- a/packages/server/src/constants/index.js
+++ b/packages/server/src/constants/index.js
@@ -1,4 +1,3 @@
 export const DEFAULT_EXPIRE = 86400000; // 1d
 export const DEFAULT_TTS = 300000; // 5m
-export const DEFAULT_DELAY = 5000; // 5s
 export const DEFAULT_RETRIES = 5;

--- a/packages/server/src/radpack.js
+++ b/packages/server/src/radpack.js
@@ -1,12 +1,13 @@
 import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import Radpack, { flatten, noop } from '@radpack/core';
-import { fetch, parseUrl } from '@radpack/core/server';
-import { DEFAULT_DELAY, DEFAULT_EXPIRE, DEFAULT_RETRIES, DEFAULT_TTS } from './constants';
+import { fetch, parseUrl, constants } from '@radpack/core/server';
+import { DEFAULT_EXPIRE, DEFAULT_RETRIES, DEFAULT_TTS } from './constants';
 
 const CWD = process.cwd();
 const SERVER_PATH = '@radpack/server';
 const SERVER_ABS_PATH = require.resolve(SERVER_PATH);
+const { DEFAULT_DELAY, DEFAULT_TIMEOUT } = constants;
 
 export default class extends Radpack {
   constructor({ registers = [], ...options } = {}) {
@@ -69,6 +70,7 @@ export default class extends Radpack {
           ? DEFAULT_TTS
           : 0,
         delay: DEFAULT_DELAY,
+        timeout: DEFAULT_TIMEOUT,
         retries: DEFAULT_RETRIES,
         ...options,
         config,
@@ -152,7 +154,7 @@ export default class extends Radpack {
   }
 
   async _fetchJson(cache, options) {
-    const { delay, retries } = options;
+    const { delay, timeout, retries } = options;
     const { url, last, etag } = cache;
     const headers = {};
     if (last) {
@@ -161,7 +163,7 @@ export default class extends Radpack {
     if (etag) {
       headers['If-None-Match'] = etag;
     }
-    const res = await fetch(url, { headers, delay, retries });
+    const res = await fetch(url, { headers, delay, timeout, retries });
     const isCacheHit = cache.json && res.status === 304;
     if (!isCacheHit && !res.ok) {
       throw Error(await res.text());


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The fields below are mandatory.
-->

## Summary
Add a default timeout and timeout option to server fetch requests

## Changelog
Default `node-fetch` timeouts to 15s

