### PR TITLE
Fix issue with building external libraries

### DIFF
--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -43,7 +43,7 @@ export default function RadpackPlugin(options) {
         return null;
       }
       const exp = getExportById(id);
-      if (exp) {
+      if (exp && exp !== options.name && !exp.startsWith(`${ options.name }/`)) {
         return { id: exp, external: true };
       }
     },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The fields below are mandatory.
-->

## Summary
When trying to re-export libraries published to npm as radpack assets, the rollup-plugin would mark the library as external, causing an infinite loop. Prior work around was to mark the library as external in the rollup configuration.

## Changelog
Better rollup support for re-exporting existing npm libraries

## Test Plan
Remove external declaration from rollup configuration
