### PR TITLE
Call done on register/watch eval

### DIFF
--- a/configs/test/unit.js
+++ b/configs/test/unit.js
@@ -11,6 +11,7 @@ export default (defaultState) => {
 
   test.before(t => {
     Object.assign(t.context, {
+      wait: ms => new Promise(resolve => setTimeout(resolve, ms)),
       fetch: globalThis.fetch = fetch()
     });
   });

--- a/packages/server/src/radpack.js
+++ b/packages/server/src/radpack.js
@@ -185,7 +185,7 @@ export default class extends Radpack {
     const index = this._registers.length;
     const { exports: exps } = this._setRegister(index, registers);
     exps.forEach(this._setExports, this);
-    options.done(urls, this);
+    options.done({ urls }, this);
     if (options.tts > 0 && urls.length) {
       this._watch(index, urls, options);
     }
@@ -227,7 +227,7 @@ export default class extends Radpack {
           nextUrls = [...options.urls];
           this._setRegister(index, registers);
           this._resetExports();
-          options.done(nextUrls, this);
+          options.done({ urls: nextUrls }, this);
         }
       }).catch(() => {
         // Revert to prior urls

--- a/packages/server/src/radpack.js
+++ b/packages/server/src/radpack.js
@@ -72,6 +72,7 @@ export default class extends Radpack {
         delay: DEFAULT_DELAY,
         timeout: DEFAULT_TIMEOUT,
         retries: DEFAULT_RETRIES,
+        done: noop,
         ...options,
         config,
         urls: new Set()
@@ -184,6 +185,7 @@ export default class extends Radpack {
     const index = this._registers.length;
     const { exports: exps } = this._setRegister(index, registers);
     exps.forEach(this._setExports, this);
+    options.done(urls, this);
     if (options.tts > 0 && urls.length) {
       this._watch(index, urls, options);
     }
@@ -225,6 +227,7 @@ export default class extends Radpack {
           nextUrls = [...options.urls];
           this._setRegister(index, registers);
           this._resetExports();
+          options.done(nextUrls, this);
         }
       }).catch(() => {
         // Revert to prior urls

--- a/packages/server/test/unit/radpack/setRegisters.test.js
+++ b/packages/server/test/unit/radpack/setRegisters.test.js
@@ -22,7 +22,7 @@ test('sets exports for each register', t => {
 });
 
 test('calls done', t => {
-  const { sut, options, stub } = t.context;
+  const { sut, instance, options, stub } = t.context;
   const done = stub();
   const urls = new Set(['a']);
   t.is(done.calls.length, 0);
@@ -30,7 +30,8 @@ test('calls done', t => {
   options.urls = urls;
   sut([{}]);
   t.is(done.calls.length, 1);
-  t.deepEqual(done.calls[0].arguments[0], [...urls]);
+  t.deepEqual(done.calls[0].arguments[0], { urls: [...urls] });
+  t.is(done.calls[0].arguments[1], instance);
 });
 
 test('calls watch', t => {

--- a/packages/server/test/unit/radpack/setRegisters.test.js
+++ b/packages/server/test/unit/radpack/setRegisters.test.js
@@ -10,7 +10,7 @@ test.beforeEach(t => {
     _setRegister: (index, registers) => ({ registers, exports: registers })
   }))();
   t.context.registers = [];
-  t.context.options = { tts: 0, urls: new Set() };
+  t.context.options = { tts: 0, urls: new Set(), done: () => {} };
   t.context.sut = (registers = t.context.registers, options = t.context.options) => t.context.instance._setRegisters(registers, options);
 });
 
@@ -19,6 +19,18 @@ test('sets exports for each register', t => {
   const registers = new Array(Math.floor(Math.random() * 10)).fill({});
   sut(registers);
   t.is(instance._setExports.calls.length, registers.length);
+});
+
+test('calls done', t => {
+  const { sut, options, stub } = t.context;
+  const done = stub();
+  const urls = new Set(['a']);
+  t.is(done.calls.length, 0);
+  options.done = done;
+  options.urls = urls;
+  sut([{}]);
+  t.is(done.calls.length, 1);
+  t.deepEqual(done.calls[0].arguments[0], [...urls]);
 });
 
 test('calls watch', t => {

--- a/packages/server/test/unit/radpack/watch.test.js
+++ b/packages/server/test/unit/radpack/watch.test.js
@@ -49,7 +49,7 @@ test('fetches register on change', async t => {
 });
 
 test('calls done on change', async t => {
-  const { sut, cache, options, stub, wait } = t.context;
+  const { sut, instance, cache, options, stub, wait } = t.context;
   const done = options.done = stub();
   t.is(done.calls.length, 0);
   t.context._loadJson = (url, opts) => {
@@ -59,7 +59,8 @@ test('calls done on change', async t => {
   sut();
   await wait(1);
   t.is(done.calls.length, 1);
-  t.deepEqual(done.calls[0].arguments[0], [...options.urls]);
+  t.deepEqual(done.calls[0].arguments[0], { urls: [...options.urls] });
+  t.is(done.calls[0].arguments[1], instance);
 });
 
 test('does not call done if no changes', async t => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The fields below are mandatory.
-->

## Summary
Expose a new `done` option when calling `register` that will be called after the initial registration completes, as well when a watch registration update completes.

## Changelog
 - Add `done` option to `@radpack/server` `register` options

