### PR TITLE
add abort signal to fetch, retry all fetches

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,10 +33,12 @@
     "access": "public"
   },
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.6",
+    "@sinonjs/fake-timers": "^9.1.2",
     "rimraf": "^3.0.2"
   },
   "license": "MIT"

--- a/packages/core/src/server/constants/index.js
+++ b/packages/core/src/server/constants/index.js
@@ -1,2 +1,3 @@
 export const DEFAULT_TIMEOUT = 15000; // 15s
 export const DEFAULT_DELAY = 5000; // 5s
+export const DEFAULT_RETRIES = 3;


### PR DESCRIPTION
## Summary
`node-fetch` dropped support for `timeout` option, so added AbortController to support signal. Also added default retries to fetch so failed CDN requests will retry.