### PR TITLE
The proper rollup plugin key is keepMinors. plural

### DIFF
--- a/docs/internals/version.md
+++ b/docs/internals/version.md
@@ -39,7 +39,7 @@ something@1.1.0 deployed, @1.0.1 is dropped
 ```
 
 In some cases this is too strict, and you may opt to also retain minor versions (
-enabled by supplying `keepMinor: true` to the rollup plugin). This is discouraged,
+enabled by supplying `keepMinors: true` to the rollup plugin). This is discouraged,
 but may be neccessary in some cases.
 
 ```sh


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The fields below are mandatory.
-->

## Summary

In the documentation under [internals/version#semantic-versioning-lite](https://godaddy.github.io/radpack/internals/version#semantic-versioning-lite) it says that the key for keeping minor versions is `keepMinor`.

this is not correct. It should be plural `keepMinors`
 [packages/build/src/parse-manifests.js#L4](https://github.com/godaddy/radpack/blob/%40radpack/webpack-plugin%401.0.7/packages/build/src/parse-manifests.js#L4)


<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
Fix typo in documentation
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
text change, none needed
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
