### PR TITLE
Remove legacy Slack references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,15 +9,10 @@ No matter how you want to get involved, we ask that you first learn what’s
 expected of anyone who participates in the project by reading the Contribution
 Guidelines and our [Code of Conduct][coc].
 
-**Please Note:** GitHub is for bug reports and contributions primarily -
-if you have a support question head over to [GoDaddy's Open Source
-Software Slack channel][slack]. You can request an invite
-[here][invite].
-
 ## Answering Questions
 
 One of the most important and immediate ways you can support this project is
-to answer questions on [Slack][slack] or [Github][issues]. Whether you’re
+to answer questions on [Github][issues]. Whether you’re
 helping a newcomer understand a feature or troubleshooting an edge case with a
 seasoned developer, your knowledge and experience with a programming language
 can go a long way to help others.
@@ -61,7 +56,7 @@ From a practical perspective, contributions are as simple as:
 If you are interested in making a large change and feel unsure about its overall
 effect, start with opening an Issue in the project's [Issue Tracker][issues]
 with a high-level proposal and discuss it with the core contributors through
-Github comments or in [Slack][slack]. After reaching a consensus with core
+Github comments. After reaching a consensus with core
 contributors about the change, discuss the best way to go about implementing it.
 
 > Tip: Keep your master branch pointing at the original repository and make
@@ -93,9 +88,6 @@ patches:
 willing to do the same for you.
 - Split your change into multiple smaller changes. The smaller your change,
 the higher the probability that somebody will take a quick look at it.
-- Mention the change on [Slack][slack]. If it is urgent, provide reasons why it
-is important to get this change landed. Remember that you are asking for valuable
-time from other professional developers.
 
 **Note that anyone is welcome to review and give feedback on a change, but only
 people with commit access to the repository can approve it.**
@@ -119,6 +111,4 @@ guide with respect to patterns, naming, documentation and testing.
 
 [issues]: https://github.com/godaddy/radpack/issues
 [coc]: ./CODE_OF_CONDUCT.md
-[slack]: https://godaddy-oss.slack.com/
 [fork]: https://help.github.com/en/articles/fork-a-repo
-[invite]: https://godaddy-oss-slack.herokuapp.com


### PR DESCRIPTION
Contributions and questions should now be handled in GitHub Issues and Discussions.