### PR TITLE
Webpack 5 fixes

### DIFF
--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -473,7 +473,12 @@ class RadpackPlugin {
         let hasEntryModule = false;
         for (const entryModule of chunkGraph.getChunkEntryModulesIterable(chunk)) {
           hasEntryModule = true;
-          if (!entryModule.resource.match(this.options.test)) {
+
+          // it must be the file types we care about or be made up of multiple dependencies of the file types we care about
+          if (
+            !entryModule.resource?.match(this.options.test) ||
+            !entryModule.dependencies?.every(dep => dep.resource?.match(this.options.test))
+          ) {
             return;
           }
         }

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -555,7 +555,7 @@ class RadpackPlugin {
     const manifest = createManifest(mergeExports(buildExports, existing), this.options);
 
     // Write to file if there are exports
-    if (manifest.exports[this.options.name]) {
+    if (manifest.exports[this.options.filename]) {
       compilation.emitAsset(this.options.filename, new RawSource(JSON.stringify(manifest)));
     }
 

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -554,8 +554,10 @@ class RadpackPlugin {
     const existing = Object.values(this.exports).filter(e => e.name === this.options.name);
     const manifest = createManifest(mergeExports(buildExports, existing), this.options);
 
-    // Write to file
-    compilation.emitAsset(this.options.filename, new RawSource(JSON.stringify(manifest)));
+    // Write to file if there are exports
+    if (manifest.exports[this.options.name]) {
+      compilation.emitAsset(this.options.filename, new RawSource(JSON.stringify(manifest)));
+    }
 
     // Replace manifest placeholder in runtime entries
     if (this.options.injectManifest) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The fields below are mandatory.
-->

## Summary
1. In some cases, there are chunks that are made up of multiple dependencies. We need to filter out chunks from being processed if those dependencies are not of the specific file types that we care about.
2. There are scenarios where a manifest does not include any exports - we should not write these files but skip them instead.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
- skipping chunks whose dependencies are not of the designated file types
- skip writing manifest files if they do not include exports

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
Tested in builder using Webpack 5.

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
