### PR TITLE
Prevent radpack registration if there is no chunk graph, correct condition to emit manifest

### DIFF
--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -301,6 +301,11 @@ class RadpackPlugin {
       }
     } else {
       const chunkGraph = compilation.chunkGraph;
+
+      if (!chunkGraph) {
+        return source;
+      }
+
       for (const entryModule of chunkGraph.getChunkEntryModulesIterable(chunk)) {
         if (!this.isMatchingResource(entryModule)) {
           return source;
@@ -555,10 +560,7 @@ class RadpackPlugin {
     const existing = Object.values(this.exports).filter(e => e.name === this.options.name);
     const manifest = createManifest(mergeExports(buildExports, existing), this.options);
 
-    // Write to file if there are exports
-    if (this.options.filename in manifest.exports) {
-      compilation.emitAsset(this.options.filename, new RawSource(JSON.stringify(manifest)));
-    }
+    compilation.emitAsset(this.options.filename, new RawSource(JSON.stringify(manifest)));
 
     // Replace manifest placeholder in runtime entries
     if (this.options.injectManifest) {

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -560,7 +560,10 @@ class RadpackPlugin {
     const existing = Object.values(this.exports).filter(e => e.name === this.options.name);
     const manifest = createManifest(mergeExports(buildExports, existing), this.options);
 
-    compilation.emitAsset(this.options.filename, new RawSource(JSON.stringify(manifest)));
+    // Write to file if there are exports
+    if (this.options.name in manifest.exports) {
+      compilation.emitAsset(this.options.filename, new RawSource(JSON.stringify(manifest)));
+    }
 
     // Replace manifest placeholder in runtime entries
     if (this.options.injectManifest) {


### PR DESCRIPTION
## Summary
There are scenarios where a compilation does not have a chunk graph, so it doesn't make sense to inject the radpack registration.

Also corrected the condition where we check the exports before emitting the manifest.

## Changelog
- prevent radpack registration injection if there is no chunk graph
- check that `options.name` exists in exports